### PR TITLE
Recent device

### DIFF
--- a/src/com/zehfernando/input/binding/KeyActionBinder.as
+++ b/src/com/zehfernando/input/binding/KeyActionBinder.as
@@ -623,12 +623,12 @@ package com.zehfernando.input.binding {
 			}
 		}
 
-        private function set recentDevice(value:GameInputDevice):void {
-            if(_recentDevice != value) {
-                _recentDevice = value;
-                _onRecentDevice.dispatch(value);
-            }
-        }
+		private function set recentDevice(value:GameInputDevice):void {
+			if(_recentDevice != value) {
+				_recentDevice = value;
+				_onRecentDevice.dispatch(value);
+			}
+		}
 
 		// ================================================================================================================
 		// PUBLIC INTERFACE -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Expose a recent device member.  This is useful if the user has multiple devices plugged in and switches between them during game-play.  Firing this event allows the UI to update to reflect the most recently used device.  Ex- switching between a DS4 & XBox360 controller.